### PR TITLE
Implement Heavy Dazed tile meshes using instanced meshes

### DIFF
--- a/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
+++ b/LongWarOfTheChosen/LongWarOfTheChosen.x2proj
@@ -1124,6 +1124,9 @@
     <Content Include="Src\LW_Overhaul\Classes\X2Item_HeavyDazedDamageType.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_PrimaryDaze.uc" />
     <Content Include="Src\LW_Overhaul\Classes\X2Effect_SecondaryDaze.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\LWHeavyDazedListener.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\LWInstancedTileComponent.uc" />
+    <Content Include="Src\LW_Overhaul\Classes\LWInstancedMeshActor.uc" />
   </ItemGroup>
   <!-- Everything below is borrowed from the https://github.com/WOTCStrategyOverhaul/CovertInfiltration project -->
   <!-- The weird stuff below (until Target) is required or otherwise ModBuddy project breaks ¯\_(ツ)_/¯ P.S. Also don't try to make it more sane -->

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWHeavyDazedListener.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWHeavyDazedListener.uc
@@ -1,0 +1,111 @@
+class LWHeavyDazedListener extends Actor implements(X2VisualizationMgrObserverInterface);
+
+var LWInstancedTileComponent TileComp;
+var bool UpdateFlag;
+
+event PostBeginPlay()
+{
+	TileComp = new class'LWInstancedTileComponent';
+	TileComp.CustomInit();
+	TileComp.SetMesh(StaticMesh(DynamicLoadObject("UI3D_XPack.Tile.BuddyTile_Safe_Enter", class'StaticMesh')));
+	`XCOMVISUALIZATIONMGR.RegisterObserver(self);
+}
+
+event Tick(float DeltaTime)
+{
+	if (UpdateFlag && !`XCOMVISUALIZATIONMGR.VisualizerBusy())
+	{
+		UpdateFlag = false;
+		UpdateDazedTiles();
+	}
+}
+
+function UpdateDazedTiles()
+{
+	local XComGameStateVisualizationMgr VisMgr;
+	local XComGameStateHistory History;
+	local XComWorldData WorldData;
+	local int LastStateHistoryVisualized;
+	local XComGameState_Unit Unit, ControllingUnit;
+	local XComGameState_Ability Ability;
+	local int LocalPlayerID;
+	local ETeam TeamFlag;
+
+	local vector UnitPos;
+	local array<TilePosPair> TilePosPairs;
+	local TilePosPair Pair;
+
+	local array<TTile> Tiles;
+	Tiles.Length = 0;
+
+	VisMgr = `XCOMVISUALIZATIONMGR;
+	History = `XCOMHISTORY;
+	WorldData = `XWORLD;
+	LastStateHistoryVisualized = VisMgr.LastStateHistoryVisualized;
+	
+	ControllingUnit = XComTacticalController(class'WorldInfo'.static.GetWorldInfo().GetALocalPlayerController())
+							.ControllingUnitVisualizer.GetVisualizedGameState();
+
+	LocalPlayerID = `TACTICALRULES.GetLocalClientPlayerObjectID();
+	TeamFlag = XComGameState_Player(History.GetGameStateForObjectID(LocalPlayerID)).TeamFlag;
+	foreach History.IterateByClassType(class'XComGameState_Unit', Unit, , , LastStateHistoryVisualized)
+	{
+		// Only Allies...
+		if (Unit.IsEnemyTeam(TeamFlag)) continue;
+
+		// ... affected by HeavyDazed...
+		if (Unit.AffectedByEffectNames.Find(class'X2StatusEffects_LW'.default.HeavyDazedName) == INDEX_NONE) continue;
+
+		// ... that we have vision on (TODO: History Index???)...
+		if (!class'X2TacticalVisibilityHelpers'.static.CanSquadSeeTarget(LocalPlayerID, Unit.GetReference().ObjectID)) continue;
+
+		// ... TODO: Any more conditions?
+
+		UnitPos = WorldData.GetPositionFromTileCoordinates(Unit.TileLocation);
+		// Collect tiles in radius
+		TilePosPairs.Length = 0;
+		WorldData.CollectTilesInSphere(TilePosPairs, UnitPos, class'X2Ability_DefaultAbilitySet'.default.REVIVE_RANGE_UNITS);
+		foreach TilePosPairs(Pair)
+		{
+			if (WorldData.IsFloorTileAndValidDestination(Pair.Tile, ControllingUnit) && WorldData.CanUnitsEnterTile(Pair.Tile))
+			{
+				Tiles.AddItem(Pair.Tile);
+			}
+		}
+	}
+
+	foreach History.IterateByClassType(class'XComGameState_Ability', Ability, , , LastStateHistoryVisualized)
+	{
+		break;
+	}
+
+	TileComp.SetMockParameters(Ability);
+	TileComp.SetTiles(Tiles);
+	TileComp.SetMockParameters(none);
+}
+
+// TODO?: Replace this with a HL event in XComPathingPawn
+
+/// <summary>
+/// Called when an active visualization block is marked complete 
+/// </summary>
+event OnVisualizationBlockComplete(XComGameState AssociatedGameState)
+{
+	UpdateFlag = true;
+}
+
+/// <summary>
+/// Called when the visualizer runs out of active and pending blocks, and becomes idle
+/// </summary>
+event OnVisualizationIdle()
+{
+	UpdateFlag = true;
+}
+
+/// <summary>
+/// Called when the active unit selection changes
+/// </summary>
+event OnActiveUnitChanged(XComGameState_Unit NewActiveUnit)
+{
+	UpdateFlag = true;
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWInstancedMeshActor.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWInstancedMeshActor.uc
@@ -1,0 +1,13 @@
+class LWInstancedMeshActor extends XComInstancedMeshActor;
+
+defaultproperties
+{
+	Begin Object Name=InstancedMeshComponent0
+		AbsoluteTranslation=true
+		AbsoluteRotation=true
+		TranslucencySortPriority=-1000
+		HiddenGame=false
+		HiddenEditor=true
+		HideDuringCinematicView=true
+	End Object
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWInstancedTileComponent.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/LWInstancedTileComponent.uc
@@ -1,0 +1,32 @@
+class LWInstancedTileComponent extends X2TargetingMethod;
+
+function CustomInit()
+{
+    AOEMeshActor = `XWORLDINFO.Spawn(class'LWInstancedMeshActor');
+}
+ 
+function SetMesh(StaticMesh Mesh)
+{
+    AOEMeshActor.InstancedMeshComponent.SetStaticMesh(Mesh);
+}
+
+// X2TargetingMethod requires that Ability is set. Do it with this function.
+function SetMockParameters(XComGameState_Ability AbilityState)
+{
+	Ability = AbilityState;
+}
+
+function SetTiles(const out array<TTile> Tiles)
+{
+    DrawAOETiles(Tiles);
+}
+ 
+function Dispose()
+{
+    AOEMeshActor.Destroy();
+}
+
+function SetVisible(bool Visible)
+{
+	AOEMeshActor.SetVisible(Visible);
+}

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_TacticalHUD.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIScreenListener_TacticalHUD.uc
@@ -38,6 +38,9 @@ event OnInit(UIScreen Screen)
 	// Used for when a campaign is loaded from a save in tactical.
 	if (`LWOVERHAULOPTIONS == none)
 		class'XComGameState_LWOverhaulOptions'.static.CreateModSettingsState_ExistingCampaign(class'XComGameState_LWOverhaulOptions');
+
+	// Spawn Heavy Dazed visualization
+	`XWORLDINFO.Spawn(class'LWHeavyDazedListener');
 }
 
 function EventListenerReturn OnTacticalBeginPlay(Object EventData, Object EventSource, XComGameState GameState, Name EventID, Object CallbackData)


### PR DESCRIPTION
Weirdly enough, this makes the mesh properly animated: ![image](https://cdn.discordapp.com/attachments/545645785606520832/661291203479994378/unknown.png)

If you want to fix that, use a different mesh with the animation disabled! I don't know why the pathing pawn ones don't show it...